### PR TITLE
fix time issue where local server and Github Action server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   cron:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      TZ: Asia/Seoul
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Fixes #3 

## 변경사항
깃허브 액션 서버의 시간을 한국 표준 시간이 될 수 있도록, 타임존에 대한 환경변수를 추가함